### PR TITLE
修复【权限管理-操作员管理】中根据操作员姓名模糊查询错误

### DIFF
--- a/roncoo-pay-service/src/main/resources/mybatis/mapper/permission/PmsOperatorMapper.xml
+++ b/roncoo-pay-service/src/main/resources/mybatis/mapper/permission/PmsOperatorMapper.xml
@@ -84,7 +84,7 @@
 		<if test="status != null and status != ''"> and status = #{status}</if>
 		<if test="type != null and type != ''"> and type = #{type}</if>
 		<!-- Like query -->
-		<if test="realName != null and realName != ''"> and REALNAME like CONCAT(CONCAT('%', #{realName}), '%')</if>
+		<if test="realName != null and realName != ''"> and real_name like CONCAT(CONCAT('%', #{realName}), '%')</if>
 	</sql>
 
 	<select id="listPage" parameterType="java.util.Map" resultMap="beanMap">


### PR DESCRIPTION
**错误描述：** 在【权限管理-操作员管理】中根据操作员姓名模糊查询时，会报错“获取数据失败”

**原因：** 在文件`roncoo-pay-service\src\main\resources\mybatis\mapper\permission\PmsOperatorMapper.xml`中的`<sql id="condition_sql">`中，操作人姓名字段写的是`REALNAME `，而表`pms_operator `中操作人真实姓名字段是`real_name`，故在对表`pms_operator `查询字段`REALNAME `时会报没有此列的错误

**解决办法：** 将`REALNAME ` 改为`real_name`