### PR TITLE
fix(sec): upgrade org.jdom:jdom2 to 2.0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -64,7 +63,7 @@
 		<commons-lang.version>2.6</commons-lang.version>
 		<commons-httpclient.version>3.1</commons-httpclient.version>
 		<dom4j.version>2.1.3</dom4j.version>
-		<jdom.version>2.0.6</jdom.version>
+		<jdom.version>2.0.6.1</jdom.version>
 		<javax.json-api.version>1.1.4</javax.json-api.version>
 		<commons-io.version>2.7</commons-io.version>
 		<httpclient.version>4.5.7</httpclient.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.jdom:jdom2 2.0.6
- [CVE-2021-33813](https://www.oscs1024.com/hd/CVE-2021-33813)


### What did I do？
Upgrade org.jdom:jdom2 from 2.0.6 to 2.0.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS